### PR TITLE
Add TileJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ It allows to provide links to web maps for visualization purposes. Currently, OG
 
 ## Link Object Fields
 
-This extension only extends the [Link Object](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md#link-object)
-used in all STAC entities (Catalogs, Collections, Items). It requires specific relation types to be set for the `rel` field in the 
+This extension can extend the [Link Object](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md#link-object)
+used in all STAC entities (Catalogs, Collections, Items). It requires specific relation types to be set for the `rel` field in the
 Link Object.
 
 An attribution field is not defined as part of this extension, but it is RECOMMENDED to provide an attribution
@@ -31,22 +31,34 @@ in the top-level object of the document via the `attribution` field as defined i
 
 Links to a [OGC Web Map Tile Service](https://www.ogc.org/standards/wmts) (WMTS) implementation (versions 1.x).
 
-| Field Name      | Type                 | Description |
-| --------------- | -------------------- | ----------- |
-| rel             | string               | **REQUIRED**. Must be set to `wmts`. |
-| href            | string               | **REQUIRED**. Link to the WMTS, without any WMTS specific query parameters. |
-| wmts:layer      | string\|\[string]    | **REQUIRED**. The layers to show on the map, either a list of layer names or a single layer name. |
+| Field Name      | Type                 | Description                                                                                                      |
+| --------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| rel             | string               | **REQUIRED**. Must be set to `wmts`.                                                                             |
+| href            | string               | **REQUIRED**. Link to the WMTS, without any WMTS specific query parameters.                                      |
+| wmts:layer      | string\|\[string]    | **REQUIRED**. The layers to show on the map, either a list of layer names or a single layer name.                |
 | wmts:dimensions | Map\<string, string> | Any additional dimension parameters to add to the request as key-value-pairs, usually added as query parameters. |
 
 ### XYZ
 
 Links to a XYZ, also known as slippy map.
 
-| Field Name      | Type                 | Description |
-| --------------- | -------------------- | ----------- |
-| rel             | string               | **REQUIRED**. Must be set to `xyz`. |
-| href            | string               | **REQUIRED**. Link to the XYZ as a templates URI. MUST include the following placeholders: `{x}`, `{y}` and `{z}`. MAY include a placeholder for the server: `{s}` |
-| xyz:servers     | array                | REQUIRED if `{s}` is used in the `href`. A list of allowed values for the placeholder `{s}`. |
+| Field Name  | Type   | Description                                                                                                                                                        |
+| ----------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| rel         | string | **REQUIRED**. Must be set to `xyz`.                                                                                                                                |
+| href        | string | **REQUIRED**. Link to the XYZ as a templates URI. MUST include the following placeholders: `{x}`, `{y}` and `{z}`. MAY include a placeholder for the server: `{s}` |
+| xyz:servers | array  | REQUIRED if `{s}` is used in the `href`. A list of allowed values for the placeholder `{s}`.                                                                       |
+
+## Asset Object Fields
+
+In addition to the above link extensions,
+[Asset Objects](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md#asset-object)
+can specify a specific role that links to a [TileJSON](https://github.com/mapbox/tilejson-spec) document.
+
+| Field Name | Type       | Description                                        |
+| ---------- | ---------- | -------------------------------------------------- |
+| roles      | `[string]` | **REQUIRED**. Must include `tiles` as a role.      |
+| href       | ``string   | **REQUIRED**. Link to the valid TileJSON document. |
+| type       | `string`   | RECOMMENDED to be set to `application/json`        |
 
 ## Contributing
 
@@ -58,10 +70,10 @@ for running tests are copied here for convenience.
 
 ### Running tests
 
-The same checks that run as checks on PR's are part of the repository and can be run locally to verify that changes are valid. 
+The same checks that run as checks on PR's are part of the repository and can be run locally to verify that changes are valid.
 To run tests locally, you'll need `npm`, which is a standard part of any [node.js installation](https://nodejs.org/en/download/).
 
-First you'll need to install everything with npm once. Just navigate to the root of this repository and on 
+First you'll need to install everything with npm once. Just navigate to the root of this repository and on
 your command line run:
 ```bash
 npm install

--- a/README.md
+++ b/README.md
@@ -9,8 +9,14 @@
 
 This document explains the Web Map Links Extension to the
 [SpatioTemporal Asset Catalog](https://github.com/radiantearth/stac-spec) (STAC) specification.
-It allows to provide links to web maps for visualization purposes. Currently, OGC WMTS and XYZ are supported.
+It allows to provide links to web map services for visualization purposes.
 
+The following services are supported:
+- [OGC WMTS](#ogc-wmts)
+- [TileJSON](#tilejson)
+- [XYZ](#xyz)
+
+Important resources in this extension:
 - Examples:
   - [Item example](examples/item.json): Shows the basic usage of the extension in a STAC Item
   - [Collection example](examples/collection.json): Shows the basic usage of the extension in a STAC Collection
@@ -35,6 +41,7 @@ Links to a [OGC Web Map Tile Service](https://www.ogc.org/standards/wmts) (WMTS)
 | --------------- | -------------------- | ----------- |
 | rel             | string               | **REQUIRED**. Must be set to `wmts`. |
 | href            | string               | **REQUIRED**. Link to the WMTS, without any WMTS specific query parameters. |
+| type            | string               | Recommended to be set to the media type the Capabilities document, usually `application/xml`. |
 | href:servers    | \[string]            | See [href:servers](#hrefservers) below for details. |
 | wmts:layer      | string\|\[string]    | **REQUIRED**. The layers to show on the map by default, either a list of layer names or a single layer name. |
 | wmts:dimensions | Map\<string, string> | Any additional dimension parameters to add to the request as key-value-pairs, usually added as query parameters. |
@@ -51,11 +58,12 @@ The `href` can contain an optional server placeholder `{s}`. If `{s}` is used, t
 
 Links to a XYZ, also known as slippy map.
 
-| Field Name      | Type                 | Description |
-| --------------- | -------------------- | ----------- |
-| rel             | string               | **REQUIRED**. Must be set to `xyz`. |
-| href            | string               | **REQUIRED**. Link to the XYZ as a templated URI. |
-| href:servers    | \[string]            | See [href:servers](#hrefservers) below for details. |
+| Field Name   | Type      | Description |
+| ------------ | --------- | ----------- |
+| rel          | string    | **REQUIRED**. Must be set to `xyz`. |
+| href         | string    | **REQUIRED**. Link to the XYZ as a templated URI. |
+| type         | string    | Recommended to be set to the image file type the XYZ returns by default, usually `image/png` or `image/jpeg`. |
+| href:servers | \[string] | See [href:servers](#hrefservers) below for details. |
 
 #### href
 
@@ -69,11 +77,11 @@ e.g. the `{r}` parameter in Leaflet could be replaced by `2x`.
 
 Links to a [TileJSON](https://github.com/mapbox/tilejson-spec) document.
 
-| Field Name | Type       | Description                                        |
-| ---------- | ---------- | -------------------------------------------------- |
-| rel             | string               | **REQUIRED**. Must be set to `tilejson`. |
-| href       | ``string   | **REQUIRED**. Link to the valid TileJSON document. |
-| type       | `string`   | RECOMMENDED to be set to `application/json`        |
+| Field Name | Type   | Description |
+| ---------- | ------ | ----------- |
+| rel        | string | **REQUIRED**. Must be set to `tilejson`. |
+| href       | string | **REQUIRED**. Link to the valid TileJSON document. |
+| type       | string | Recommended to be set to `application/json` |
 
 ### General
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It allows to provide links to web maps for visualization purposes. Currently, OG
 
 ## Link Object Fields
 
-This extension can extend the [Link Object](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md#link-object)
+This extension only extends the [Link Object](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md#link-object)
 used in all STAC entities (Catalogs, Collections, Items). It requires specific relation types to be set for the `rel` field in the
 Link Object.
 
@@ -56,6 +56,7 @@ Links to a XYZ, also known as slippy map.
 | rel             | string               | **REQUIRED**. Must be set to `xyz`. |
 | href            | string               | **REQUIRED**. Link to the XYZ as a templated URI. |
 | href:servers    | \[string]            | See [href:servers](#hrefservers) below for details. |
+
 #### href
 
 For XYZ, the `href` is a templated URI.

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -56,16 +56,12 @@
         "b",
         "c"
       ]
-    }
-  ],
-  "assets": {
-    "tiles": {
+    },
+    {
+      "href": "https://maps.example.com/collection/tilejson.json",
+      "rel": "tilejson",
       "title": "TileJSON",
-      "href": "https://maps.example.com/colleciton/tilejson.json",
-      "type": "application/json",
-      "roles": [
-        "tiles"
-      ]
+      "type": "application/json"
     }
-  }
+  ]
 }

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -41,6 +41,7 @@
     {
       "href": "https://maps.example.com/wmts",
       "rel": "wmts",
+      "type": "application/xml",
       "title": "RGB composite visualized through a WMTS",
       "wmts:layer": "rgb",
       "wmts:dimensions": {
@@ -48,8 +49,9 @@
       }
     },
     {
-      "href": "https://{s}.maps.example.com/xyz/{z}/{x}/{y}",
+      "href": "https://{s}.maps.example.com/xyz/{z}/{x}/{y}.png",
       "rel": "xyz",
+      "type": "image/png",
       "title": "RGB composite visualized through a XYZ",
       "href:servers": [
         "a",

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -57,5 +57,15 @@
         "c"
       ]
     }
-  ]
+  ],
+  "assets": {
+    "tiles": {
+      "title": "TileJSON",
+      "href": "https://maps.example.com/colleciton/tilejson.json",
+      "type": "application/json",
+      "roles": [
+        "tiles"
+      ]
+    }
+  }
 }

--- a/examples/item.json
+++ b/examples/item.json
@@ -39,18 +39,7 @@
     ]
   },
   "properties": {
-    "datetime": "2020-12-11T22:38:32Z",
-    "template:new_field": "test",
-    "template:xyz": {
-      "x": 1,
-      "y": 2,
-      "z": 3
-    },
-    "template:another_one": [
-      1,
-      2,
-      3
-    ]
+    "datetime": "2020-12-11T22:38:32Z"
   },
   "attribution": "&copy; 2022 The Example Corp.",
   "links": [
@@ -75,8 +64,6 @@
   ],
   "assets": {
     "data": {
-      "href": "https://example.com/examples/file.xyz",
-      "template:new_field": "test"
     }
   }
 }

--- a/examples/item.json
+++ b/examples/item.json
@@ -64,6 +64,15 @@
   ],
   "assets": {
     "data": {
+      "href": "https://example.com/examples/file.xyz"
+    },
+    "tiles": {
+      "title": "TileJSON",
+      "href": "https://maps.example.com/item/tilejson.json",
+      "type": "application/json",
+      "roles": [
+        "tiles"
+      ]
     }
   }
 }

--- a/examples/item.json
+++ b/examples/item.json
@@ -67,5 +67,6 @@
       "title": "TileJSON",
       "type": "application/json"
     }
-  ]
+  ],
+  "assets": {}
 }

--- a/examples/item.json
+++ b/examples/item.json
@@ -60,19 +60,12 @@
       "href": "https://maps.example.com/xyz/{z}/{x}/{y}",
       "rel": "xyz",
       "title": "RGB composite visualized through a XYZ"
-    }
-  ],
-  "assets": {
-    "data": {
-      "href": "https://example.com/examples/file.xyz"
     },
-    "tiles": {
-      "title": "TileJSON",
+    {
       "href": "https://maps.example.com/item/tilejson.json",
-      "type": "application/json",
-      "roles": [
-        "tiles"
-      ]
+      "rel": "tilejson",
+      "title": "TileJSON",
+      "type": "application/json"
     }
-  }
+  ]
 }

--- a/examples/item.json
+++ b/examples/item.json
@@ -50,6 +50,7 @@
     {
       "href": "https://maps.example.com/wmts",
       "rel": "wmts",
+      "type": "application/xml",
       "title": "RGB composite visualized through a WMTS",
       "wmts:layer": [
         "streets",
@@ -57,8 +58,9 @@
       ]
     },
     {
-      "href": "https://maps.example.com/xyz/{z}/{x}/{y}",
+      "href": "https://maps.example.com/xyz/{z}/{x}/{y}.jpg",
       "rel": "xyz",
+      "type": "image/jpeg",
       "title": "RGB composite visualized through a XYZ"
     },
     {

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -35,7 +35,8 @@
           "rel": {
             "enum": [
               "xyz",
-              "wmts"
+              "wmts",
+              "tilejson"
             ]
           }
         }


### PR DESCRIPTION
This PR adds the ability to specify web map links via [TileJSON](https://github.com/mapbox/tilejson-spec) through specifying an Asset with `tiles` in the Asset roles.