### PR TITLE
Add ArcGIS FeatureServer Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,9 @@ Links to a [ArcGIS FeatureServer](https://developers.arcgis.com/rest/services-re
 | Field Name      | Type                 | Description |
 | --------------- | -------------------- | ----------- |
 | rel             | string               | **REQUIRED**. Must be set to `featureserver`. |
-| href            | string               | **REQUIRED**. Link to a FeatureServer service. Usually has the following form `https://<root>/<serviceName>/FeatureServer`|
+| href            | string               | **REQUIRED**. Link to a FeatureServer service. Usually has the following form `https://<root>/<serviceName>/FeatureServer` |
 | type            | string               | Recommended to be set to `application/json` |
 | featureserver:layers  | Map<string, string> | The layers included in the service. The key should be used as the `LayerId` when querying the service. For example: `https://<root>/<serviceName>/FeatureServer/<layerId>/query` |
-
 
 ### General
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Links to a [ArcGIS FeatureServer](https://developers.arcgis.com/rest/services-re
 
 | Field Name      | Type                 | Description |
 | --------------- | -------------------- | ----------- |
-| rel             | string               | **REQUIRED**. Must be set to `featureserver`. |
+| rel             | string               | **REQUIRED**. Must be set to `arcgis-featureserver`. |
 | href            | string               | **REQUIRED**. Link to a FeatureServer service. Usually has the following form `https://<root>/<serviceName>/FeatureServer` |
 | type            | string               | Recommended to be set to `application/json` |
 | featureserver:layers  | Map<string, string> | The layers included in the service. The key should be used as the `LayerId` when querying the service. For example: `https://<root>/<serviceName>/FeatureServer/<layerId>/query` |

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Links to a [ArcGIS FeatureServer](https://developers.arcgis.com/rest/services-re
 | rel             | string               | **REQUIRED**. Must be set to `featureserver`. |
 | href            | string               | **REQUIRED**. Link to a FeatureServer service. Usually has the following form `https://<root>/<serviceName>/FeatureServer`|
 | type            | string               | Recommended to be set to `application/json` |
-| featureserver:layers  | Map<string, string> | Layers |
+| featureserver:layers  | Map<string, string> | The layers included in the service. The key should be used as the `LayerId` when querying the service. For example: `https://<root>/<serviceName>/FeatureServer/<layerId>/query` |
 
 
 ### General

--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ Links to a [TileJSON](https://github.com/mapbox/tilejson-spec) document.
 | href       | string | **REQUIRED**. Link to the valid TileJSON document. |
 | type       | string | Recommended to be set to `application/json`. |
 
+### FeatureServer
+
+Links to a [ArcGIS FeatureServer](https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer/) service. 
+
+| Field Name      | Type                 | Description |
+| --------------- | -------------------- | ----------- |
+| rel             | string               | **REQUIRED**. Must be set to `featureserver`. |
+| href            | string               | **REQUIRED**. Link to a FeatureServer service. Usually has the following form `https://<root>/<serviceName>/FeatureServer`|
+| type            | string               | Recommended to be set to `application/json` |
+| featureserver:layers  | Map<string, string> | Layers |
+
+
 ### General
 
 The following field applies to multiple types of web mapping services:

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -95,6 +95,15 @@
       "pmtiles:layers": [
         "streets"
       ]
+    },
+    {
+      "href": "https://service.arcgis.com/arcgis/rest/datast/FeatureServer",
+      "rel": "featureserver",
+      "title": "ArcGIS FeatureServer",
+      "type": "application/json",
+      "featureserver:layers": {
+        "0": "streets"
+      }
     }
   ]
 }

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -98,7 +98,7 @@
     },
     {
       "href": "https://service.arcgis.com/arcgis/rest/datast/FeatureServer",
-      "rel": "featureserver",
+      "rel": "arcgis-featureserver",
       "title": "ArcGIS FeatureServer",
       "type": "application/json",
       "featureserver:layers": {

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -165,6 +165,31 @@
                 }
               }
             }
+          },
+          {
+            "$comment": "Defines FeatureServer links",
+            "if": {
+              "properties": {
+                "rel": {
+                  "const": "featureserver"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "pmtiles:layers": {
+                  "type": "object",
+                  "items": {
+                    "type": "string",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              }
+            }
           }
         ]
       }

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -171,21 +171,17 @@
             "if": {
               "properties": {
                 "rel": {
-                  "const": "featureserver"
+                  "const": "arcgis-featureserver"
                 }
               }
             },
             "then": {
               "properties": {
-                "pmtiles:layers": {
+                "featureserver:layers": {
                   "type": "object",
-                  "items": {
+                  "additionalProperties": {
                     "type": "string",
-                    "minItems": 1,
-                    "items": {
-                      "type": "string",
-                      "minLength": 1
-                    }
+                    "minLength": 1
                   }
                 }
               }


### PR DESCRIPTION
## Description 

The [NASA Impact VEDA](https://docs.openveda.cloud/) project is working on referencing ArcGIS datasets in our STAC Catalog. We are doing this through the [pyarc2stac](https://github.com/NASA-IMPACT/pyarc2stac) library that gathers ArcGIS metadata and creates STAC collections. References to ArcGIS servers are captured in the Collection `links` list while using the web-map-links extension. 

This PR adds FeatureServer as an option for web map links.
