### PR TITLE
Add Imageserver WCS extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following services are supported:
 
 - [3D Tiles](#3d-tiles)
 - [OGC WMS](#ogc-wms)
+- [OGC WCS](#ogc-wcs)
 - [OGC WMTS](#ogc-wmts)
 - [PMTiles](#pmtiles)
 - [TileJSON](#tilejson)
@@ -68,6 +69,15 @@ If you want to send multiple layers in a single request, provide them as a strin
 `wms:layers` and `wms:styles` work in parallel, so the first style in the array will be used for the first layer, etc.
 
 - [More details on the mapping between WMS query parameters and the STAC fields](./wms.md)
+
+### OGC WCS
+
+Links to a [OGC Web Coverage Service](https://www.ogc.org/standards/wcs/) (WCS) implementation (versions 2.0.x).
+
+| Field Name      | Type                 | Description |
+| --------------- | -------------------- | ----------- |
+| rel             | string               | **REQUIRED**. Must be set to `wcs`. |
+| href            | string               | **REQUIRED**. Link to the WCS, without any WCS specific query parameters. |
 
 ### OGC WMTS
 

--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ If you want to send multiple layers in a single request, provide them as a strin
 
 ### OGC WCS
 
-Links to a [OGC Web Coverage Service](https://www.ogc.org/standards/wcs/) (WCS) implementation (versions 2.0.x).
+Links to a [OGC Web Coverage Service](https://www.ogc.org/standards/wcs/) (WCS) implementation.
 
 | Field Name      | Type                 | Description |
 | --------------- | -------------------- | ----------- |
 | rel             | string               | **REQUIRED**. Must be set to `wcs`. |
 | href            | string               | **REQUIRED**. Link to the WCS, without any WCS specific query parameters. |
+| version         | string               | **REQUIRED**. WCS service version indicator  |
 | wcs:coverages   | \[string]            | **REQUIRED**. The coverage ids to request coverage for at a selected set of spatio-temporal locations, expedited in some coverage encoding format |
 | type            | string               | The media type to be used for the tile requests, e.g. `image/tiff` or `image/netcdf`. |
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Links to a [OGC Web Coverage Service](https://www.ogc.org/standards/wcs/) (WCS) 
 | --------------- | -------------------- | ----------- |
 | rel             | string               | **REQUIRED**. Must be set to `wcs`. |
 | href            | string               | **REQUIRED**. Link to the WCS, without any WCS specific query parameters. |
+| wcs:coverages   | \[string]            | **REQUIRED**. The coverage ids to request coverage for at a selected set of spatio-temporal locations, expedited in some coverage encoding format |
+| type            | string               | The media type to be used for the tile requests, e.g. `image/tiff` or `image/netcdf`. |
 
 ### OGC WMTS
 

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -90,6 +90,11 @@
       }
     },
     {
+      "href": "https://maps.example.com/ImageServer/WCSServer",
+      "rel": "wcs",
+      "title": "RGB composite analysis through a WCS"
+    },
+    {
       "href": "https://{s}.maps.example.com/xyz/{z}/{x}/{y}.png",
       "rel": "xyz",
       "type": "image/png",

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -92,7 +92,12 @@
     {
       "href": "https://maps.example.com/ImageServer/WCSServer",
       "rel": "wcs",
-      "title": "RGB composite analysis through a WCS"
+      "type": "image/tiff",
+      "title": "RGB composite analysis through a WCS",
+      "wcs:coverages": [
+        "ndgd_ozone_1hr_avg_bc_ozone_colormap",
+        "ndgd_ozone_1hr_avg_bc"
+      ]
     },
     {
       "href": "https://{s}.maps.example.com/xyz/{z}/{x}/{y}.png",

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -94,6 +94,7 @@
       "rel": "wcs",
       "type": "image/tiff",
       "title": "RGB composite analysis through a WCS",
+      "version": "2.0.1",
       "wcs:coverages": [
         "ndgd_ozone_1hr_avg_bc_ozone_colormap",
         "ndgd_ozone_1hr_avg_bc"

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -196,12 +196,21 @@
             },
             "then": {
               "required": [
-                "href"
+                "href",
+                "wcs:coverages"
               ],
               "properties": {
                 "href": {
                   "type": "string"
-                }
+                },
+                "wcs:coverages": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
               }
             }
           },

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -37,6 +37,7 @@
               "xyz",
               "wms",
               "wmts",
+              "wcs",
               "tilejson",
               "pmtiles",
               "3d-tiles"
@@ -180,6 +181,26 @@
                 },
                 "wms:transparent": {
                   "type": "boolean"
+                }
+              }
+            }
+          },
+          {
+            "$comment": "Defines WCS links",
+            "if": {
+              "properties": {
+                "rel": {
+                  "const": "wcs"
+                }
+              }
+            },
+            "then": {
+              "required": [
+                "href"
+              ],
+              "properties": {
+                "href": {
+                  "type": "string"
                 }
               }
             }

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -197,10 +197,14 @@
             "then": {
               "required": [
                 "href",
+                "version",
                 "wcs:coverages"
               ],
               "properties": {
                 "href": {
+                  "type": "string"
+                },
+                "version": {
                   "type": "string"
                 },
                 "wcs:coverages": {


### PR DESCRIPTION
This is to add WCS support. Currently the [NASA VEDA](https://docs.openveda.cloud/) project uses [pyarc2stac](https://github.com/NASA-IMPACT/pyarc2stac) for WMS support and are looking to also add WCS for timeseries analysis capabilities. This is to add the spec to web-map-links extensions.

Documentation and References used:
* [Section 8.4.1 GetCoverage request OGC WCS doc](https://docs.ogc.org/is/09-110r3/09-110r3.pdf)
* [EOx server WCS GetCoverage request parameters doc](https://docs.eoxserver.org/en/0.4/users/EO-WCS_request_parameters.html#getcoverage)